### PR TITLE
Release v2.0.108

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Note that using Unicode characters in spinners may be unreliable, depending on y
 
 ## Installation
 
-spinner is available as a Maven artifact from [Clojars](https://clojars.org/com.github.pmonks/spinner).
+`spinner` is available as a Maven artifact from [Clojars](https://clojars.org/com.github.pmonks/spinner).
 
 ### Trying it Out
 
@@ -40,7 +40,7 @@ $ lein try com.github.pmonks/spinner
 
 ## Usage
 
-The spinner functionality is provided by the `spinner.core` namespace.
+The functionality is provided by the `spinner.core` namespace.
 
 Require it in the REPL:
 

--- a/src/spinner/core.clj
+++ b/src/spinner/core.clj
@@ -84,15 +84,15 @@
 (defn- save-cursor!
   "Issues both SCO and DEC save-cursor ANSI codes, for maximum compatibility."
   []
-  (jansi/save-cursor!)
-  (clojure.core/print "\u001B7")
+  (jansi/save-cursor!)             ; JANSI uses SCO code for cursor positioning, which is unfortunate as they're less widely supported
+  (clojure.core/print "\u001B7")   ; So we manually send a DEC code too
   (flush))
 
 (defn- restore-cursor!
   "Issues both SCO and DEC restore-cursor ANSI codes, for maximum compatibility."
   []
-  (jansi/restore-cursor!)
-  (clojure.core/print "\u001B8")
+  (jansi/restore-cursor!)          ; JANSI uses SCO code for cursor positioning, which is unfortunate as they're less widely supported
+  (clojure.core/print "\u001B8")   ; So we manually send a DEC code too
   (flush))
 
 (defn- print-pending-messages

--- a/src/spinner/core.clj
+++ b/src/spinner/core.clj
@@ -81,23 +81,37 @@
         [ov nv]
         (recur)))))
 
+(defn- save-cursor!
+  "Issues both SCO and DEC save-cursor ANSI codes, for maximum compatibility."
+  []
+  (jansi/save-cursor!)
+  (clojure.core/print "\u001B7")
+  (flush))
+
+(defn- restore-cursor!
+  "Issues both SCO and DEC restore-cursor ANSI codes, for maximum compatibility."
+  []
+  (jansi/restore-cursor!)
+  (clojure.core/print "\u001B8")
+  (flush))
+
 (defn- print-pending-messages
   "Prints all pending messages"
   []
   (when-let [messages (first (swap*! msgs (constantly nil)))]
     (clojure.core/print messages)
     (flush)
-    (jansi/save-cursor!)))
+    (save-cursor!)))
 
 #_{:clj-kondo/ignore [:unused-private-var]}
 (defn- debug-print
   "Send debug output to the upper left corner of the screen, where (hopefully) it doesn't interfere with the spinner"
   [& args]
-  (jansi/save-cursor!)
+  (save-cursor!)
   (jansi/cursor! 0 0)
   (jansi/erase-line!)
   (clojure.core/print (jansi/a :bold (jansi/fg-bright :yellow (jansi/bg :red (str "DEBUG: " (s/join " " args))))))
-  (jansi/restore-cursor!))
+  (restore-cursor!))
 
 (defn active?
   "Is the spinner active?"
@@ -134,7 +148,7 @@
           attributes  (distinct
                         (concat [(get options :attribute :default)]
                                 (get options :attributes [])))]
-      (jansi/save-cursor!)
+      (save-cursor!)
       (loop [i 0]
         (clojure.core/print (str (apply-attributes attributes
                                    (apply-colour false bg-colour
@@ -143,7 +157,7 @@
                                  " "))
         (flush)
         (Thread/sleep delay-in-ms)
-        (jansi/restore-cursor!)
+        (restore-cursor!)
         (jansi/erase-line!)
         (print-pending-messages)
         (when (active?)


### PR DESCRIPTION
com.github.pmonks/spinner release v2.0.108. See commit log for details of what's included in this release.