### PR TITLE
Release 2.0.194

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java-version }}
-      - uses: DeLaGuardo/setup-clojure@9.4
+      - uses: DeLaGuardo/setup-clojure@9.5
         with:
           cli: latest
       - uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        java-version: [ 8, 11, 17 ]
+        java-version: [ 11, 17 ]  # Note: logback no longer supports Java 8, so we've dropped that from the matrix
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 17
-      - uses: DeLaGuardo/setup-clojure@9.4
+      - uses: DeLaGuardo/setup-clojure@9.5
         with:
           cli: latest
       - uses: actions/cache@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 17
-      - uses: DeLaGuardo/setup-clojure@9.4
+      - uses: DeLaGuardo/setup-clojure@9.5
         with:
           cli: latest
       - uses: actions/cache@v3

--- a/deps.edn
+++ b/deps.edn
@@ -20,8 +20,6 @@
    {jansi-clj/jansi-clj           {:mvn/version "1.0.1"}
     com.github.pmonks/clj-wcwidth {:mvn/version "1.0.64"}}
  :aliases
-   {:build
-      {:deps        {io.github.seancorfield/build-clj {:git/tag "v0.8.3" :git/sha "7ac1f8d"}
-                     com.github.pmonks/pbr            {:mvn/version "RELEASE"}}
-       :ns-default  pbr.build}
-       :extra-paths ["src"]}}
+   {:build {:deps       {io.github.clojure/tools.build {:git/tag "v0.8.3" :git/sha "0d20256"}
+                         com.github.pmonks/pbr         {:mvn/version "RELEASE"}}
+            :ns-default pbr.build}}}


### PR DESCRIPTION
com.github.pmonks/spinner release 2.0.194. See commit log for details of what's included in this release.