### PR TITLE
Release 2.0.225

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        java-version: [ 11, 17 ]  # Note: logback no longer supports Java 8, so we've dropped that from the matrix
+        java-version: [ 11, 17, 21 ]  # Note: pbr (via lice-comb) no longer supports JDK 8
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        java-version: [ 11, 17, 21 ]  # Note: pbr (via lice-comb) no longer supports JDK 8
+        java-version: [ 8, 11, 17, 21 ]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,18 +11,16 @@ jobs:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@master
 
-  CI:
+  run_ci_matrix:
     needs: skip_check
     if: ${{ needs.skip_check.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
-
     strategy:
       matrix:
         java-version: [ 8, 11, 17, 21 ]
-
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java-version }}
@@ -40,3 +38,33 @@ jobs:
 
       - name: Run CI checks
         run: clojure -Srepro -J-Dclojure.main.report=stderr -T:build ci
+
+  # Adapted from https://brunoscheufler.com/blog/2022-04-09-the-required-github-status-check-that-wasnt
+  after_ci_matrix:
+    needs: run_ci_matrix
+    runs-on: ubuntu-latest
+    if: success()
+    outputs:
+      success: ${{ steps.setoutput.outputs.success }}
+    steps:
+      - id: setoutput
+        run: echo "::set-output name=success::true"
+
+  CI:
+    runs-on: ubuntu-latest
+    if: always()
+    needs: [skip_check, run_ci_matrix, after_ci_matrix]
+    steps:
+      - run: |
+          skipped="${{ needs.skip_check.outputs.should_skip }}"
+          passed="${{ needs.after_ci_matrix.outputs.success }}"
+          if [[ $skipped == "true" ]]; then
+            echo "CI matrix skipped"
+            exit 0
+          elif [[ $passed == "true" ]]; then
+            echo "CI matrix passed"
+            exit 0
+          else
+            echo "CI matrix failed"
+            exit 1
+          fi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0    # Make sure we get the full history, or else the version number gets screwed up
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 21

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 17
+          java-version: 21
       - uses: DeLaGuardo/setup-clojure@12.1
         with:
           cli: latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 17
+          java-version: 21
       - uses: DeLaGuardo/setup-clojure@12.1
         with:
           cli: latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 21

--- a/LICENSE.spdx
+++ b/LICENSE.spdx
@@ -1,4 +1,4 @@
-SPDXVersion: SPDX-2.1
+SPDXVersion: SPDX-2.3
 DataLicense: CC0-1.0
 Creator: Peter Monks
 PackageName: com.github.pmonks/spinner

--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ Note that using Unicode characters in progress indicators may be unreliable, dep
 
 2. If you're using the Clojure CLI tools, you **must** use the `clojure` binary, as the `clj` binary wraps the JVM in `rlwrap` which then incorrectly interprets some of the ANSI escape sequences emitted by `spinner`. Some other readline alternatives (notably [Rebel Readline](https://github.com/bhauman/rebel-readline)) have been reported to work correctly.
 
+#### deps-try
+
+Doesn't work properly, for the same reason the `clj` command line doesn't work properly (`rlwrap` intercepts the ANSI escape sequences emitted by this library and misinterprets them).
+
 #### Clojure CLI
 
 ```shell

--- a/deps.edn
+++ b/deps.edn
@@ -17,7 +17,7 @@
 ;
 
 {:deps
-   {jansi-clj/jansi-clj           {:mvn/version "1.0.1"}   ; Do not upgrade to 1.0.2 - it's broken!
+   {jansi-clj/jansi-clj           {:mvn/version "1.0.3"}
     com.github.pmonks/clj-wcwidth {:mvn/version "1.0.85"}}
  :aliases
    {:build {:deps       {com.github.pmonks/pbr {:mvn/version "RELEASE"}}

--- a/deps.edn
+++ b/deps.edn
@@ -17,8 +17,8 @@
 ;
 
 {:deps
-   {jansi-clj/jansi-clj           {:mvn/version "1.0.1"}   ; Do not upgrade to 1.0.2 - it's broken!
-    com.github.pmonks/clj-wcwidth {:mvn/version "1.0.64"}}
+   {jansi-clj/jansi-clj           {:mvn/version "1.0.2"}   ; Do not upgrade to 1.0.2 - it's broken!
+    com.github.pmonks/clj-wcwidth {:mvn/version "1.0.85"}}
  :aliases
    {:build {:deps       {com.github.pmonks/pbr {:mvn/version "RELEASE"}}
             :ns-default pbr.build}}}

--- a/deps.edn
+++ b/deps.edn
@@ -17,7 +17,7 @@
 ;
 
 {:deps
-   {jansi-clj/jansi-clj           {:mvn/version "1.0.1"}   ; Do not upgrade to 1.0.2 - it's broken!
+   {jansi-clj/jansi-clj           {:mvn/version "1.0.2"}   ; Do not upgrade to 1.0.2 - it's broken!
     com.github.pmonks/clj-wcwidth {:mvn/version "1.0.85"}}
  :aliases
    {:build {:deps       {com.github.pmonks/pbr {:mvn/version "RELEASE"}}

--- a/deps.edn
+++ b/deps.edn
@@ -17,9 +17,8 @@
 ;
 
 {:deps
-   {jansi-clj/jansi-clj           {:mvn/version "1.0.1"}
+   {jansi-clj/jansi-clj           {:mvn/version "1.0.1"}   ; Do not upgrade to 1.0.2 - it's broken!
     com.github.pmonks/clj-wcwidth {:mvn/version "1.0.64"}}
  :aliases
-   {:build {:deps       {io.github.clojure/tools.build {:git/tag "v0.9.5" :git/sha "24f2894"}
-                         com.github.pmonks/pbr         {:mvn/version "RELEASE"}}
+   {:build {:deps       {com.github.pmonks/pbr {:mvn/version "RELEASE"}}
             :ns-default pbr.build}}}

--- a/deps.edn
+++ b/deps.edn
@@ -17,7 +17,7 @@
 ;
 
 {:deps
-   {jansi-clj/jansi-clj           {:mvn/version "1.0.2"}   ; Do not upgrade to 1.0.2 - it's broken!
+   {jansi-clj/jansi-clj           {:mvn/version "1.0.1"}   ; Do not upgrade to 1.0.2 - it's broken!
     com.github.pmonks/clj-wcwidth {:mvn/version "1.0.85"}}
  :aliases
    {:build {:deps       {com.github.pmonks/pbr {:mvn/version "RELEASE"}}

--- a/src/progress/indeterminate.clj
+++ b/src/progress/indeterminate.clj
@@ -124,7 +124,7 @@ long since your dog last pooped."
       (clojure.core/print (str (ansi/apply-colours-and-attrs fg-colour bg-colour attributes (nth frames (mod i (count frames))))
                                " "))
       (flush)
-      (Thread/sleep delay-in-ms)
+      (Thread/sleep ^Long delay-in-ms)
       (ansi/restore-cursor!)
       (jansi/erase-line!)
       (print-pending-messages)


### PR DESCRIPTION
com.github.pmonks/spinner release 2.0.225. See commit log for details of what's included in this release.