### PR TITLE
Release 2.0.233

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java-version }}
-      - uses: DeLaGuardo/setup-clojure@12.4
+      - uses: DeLaGuardo/setup-clojure@12.5
         with:
           cli: latest
       - uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java-version }}
-      - uses: DeLaGuardo/setup-clojure@12.3
+      - uses: DeLaGuardo/setup-clojure@12.4
         with:
           cli: latest
       - uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,10 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java-version }}
-      - uses: DeLaGuardo/setup-clojure@12.1
+      - uses: DeLaGuardo/setup-clojure@12.3
         with:
           cli: latest
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.m2/repository

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 21
-      - uses: DeLaGuardo/setup-clojure@12.4
+      - uses: DeLaGuardo/setup-clojure@12.5
         with:
           cli: latest
       - uses: actions/cache@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,10 +17,10 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 21
-      - uses: DeLaGuardo/setup-clojure@12.1
+      - uses: DeLaGuardo/setup-clojure@12.3
         with:
           cli: latest
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.m2/repository

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 21
-      - uses: DeLaGuardo/setup-clojure@12.3
+      - uses: DeLaGuardo/setup-clojure@12.4
         with:
           cli: latest
       - uses: actions/cache@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,10 +14,10 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 21
-      - uses: DeLaGuardo/setup-clojure@12.1
+      - uses: DeLaGuardo/setup-clojure@12.3
         with:
           cli: latest
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.m2/repository

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 21
-      - uses: DeLaGuardo/setup-clojure@12.3
+      - uses: DeLaGuardo/setup-clojure@12.4
         with:
           cli: latest
       - uses: actions/cache@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 21
-      - uses: DeLaGuardo/setup-clojure@12.4
+      - uses: DeLaGuardo/setup-clojure@12.5
         with:
           cli: latest
       - uses: actions/cache@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,7 @@ jobs:
         run: clojure -Srepro -J-Dclojure.main.report=stderr -T:build docs
 
       - name: Deploy docs
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./target/doc

--- a/README.md
+++ b/README.md
@@ -32,14 +32,10 @@ Note that using Unicode characters in progress indicators may be unreliable, dep
 
 2. If you're using the Clojure CLI tools, you **must** use the `clojure` binary, as the `clj` binary wraps the JVM in `rlwrap` which then incorrectly interprets some of the ANSI escape sequences emitted by `spinner`. Some other readline alternatives (notably [Rebel Readline](https://github.com/bhauman/rebel-readline)) have been reported to work correctly.
 
-#### deps-try
-
-Doesn't work properly, for the same reason the `clj` command line doesn't work properly (`rlwrap` intercepts the ANSI escape sequences emitted by this library and misinterprets them).
-
 #### Clojure CLI
 
 ```shell
-$ clojure -Sdeps '{:deps {com.github.pmonks/spinner {:mvn/version "#.#.#"}}}'  # Where #.#.# is replaced with an actual version number (see badge above)
+$ clojure -Sdeps '{:deps {com.github.pmonks/spinner {:mvn/version "RELEASE"}}}'
 ```
 
 #### Leiningen
@@ -47,6 +43,10 @@ $ clojure -Sdeps '{:deps {com.github.pmonks/spinner {:mvn/version "#.#.#"}}}'  #
 ```shell
 $ lein trampoline try com.github.pmonks/spinner
 ```
+
+#### deps-try
+
+Doesn't work properly, for the same reason the `clj` command line doesn't work properly (`rlwrap` intercepts the ANSI escape sequences emitted by this library and misinterprets them).
 
 #### Simple REPL Session
 

--- a/pbr.clj
+++ b/pbr.clj
@@ -30,7 +30,7 @@
          :validate-pom true
          :pom          {:description      "Simple ANSI text progress indicators for command line Clojure apps."
                         :url              "https://github.com/pmonks/spinner"
-                        :licenses         [:license   {:name "Apache License 2.0" :url "http://www.apache.org/licenses/LICENSE-2.0.html"}]
+                        :licenses         [:license   {:name "Apache-2.0" :url "http://www.apache.org/licenses/LICENSE-2.0.html"}]
                         :developers       [:developer {:id "pmonks" :name "Peter Monks" :email "pmonks+spinner@gmail.com"}]
                         :scm              {:url "https://github.com/pmonks/spinner" :connection "scm:git:git://github.com/pmonks/spinner.git" :developer-connection "scm:git:ssh://git@github.com/pmonks/spinner.git"}
                         :issue-management {:system "github" :url "https://github.com/pmonks/spinner/issues"}}))

--- a/src/progress/determinate.clj
+++ b/src/progress/determinate.clj
@@ -222,6 +222,7 @@ opts is a map, optionally containing these keys:
                     (ansi/save-cursor!)
                     (jansi/cursor! 1 line))
                   (print "\r")
+                  (jansi/erase-line!)
                   (when line (ansi/restore-cursor!))))
               (flush))))))))
 


### PR DESCRIPTION
com.github.pmonks/spinner release 2.0.233. See commit log for details of what's included in this release.