### PR TITLE
Release 2.0.267

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,12 +20,12 @@ jobs:
       matrix:
         java-version: [ 8, 11, 17, 21 ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java-version }}
-      - uses: DeLaGuardo/setup-clojure@13.2
+      - uses: DeLaGuardo/setup-clojure@13.4
         with:
           cli: latest
       - uses: actions/cache@v4

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -11,5 +11,5 @@ jobs:
     container:
       image: uochan/antq
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - run: java -jar /tmp/antq/antq.jar --skip=pom --exclude=com.github.pmonks/pbr --error-format="::error file={{file}}::{{message}}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,14 +10,14 @@ jobs:
     environment: clojars
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0    # Make sure we get the full history, or else the version number gets screwed up
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 21
-      - uses: DeLaGuardo/setup-clojure@13.2
+      - uses: DeLaGuardo/setup-clojure@13.4
         with:
           cli: latest
       - uses: actions/cache@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,12 +9,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 21
-      - uses: DeLaGuardo/setup-clojure@13.2
+      - uses: DeLaGuardo/setup-clojure@13.4
         with:
           cli: latest
       - uses: actions/cache@v4

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
-| | | |
-|---:|:---:|:---:|
-| [**release**](https://github.com/pmonks/spinner/tree/release) | [![CI](https://github.com/pmonks/spinner/actions/workflows/ci.yml/badge.svg?branch=release)](https://github.com/pmonks/spinner/actions?query=workflow%3ACI+branch%3Arelease) | [![Dependencies](https://github.com/pmonks/spinner/actions/workflows/dependencies.yml/badge.svg?branch=release)](https://github.com/pmonks/spinner/actions?query=workflow%3Adependencies+branch%3Arelease) |
-| [**dev**](https://github.com/pmonks/spinner/tree/dev) | [![CI](https://github.com/pmonks/spinner/actions/workflows/ci.yml/badge.svg?branch=dev)](https://github.com/pmonks/spinner/actions?query=workflow%3ACI+branch%3Adev) | [![Dependencies](https://github.com/pmonks/spinner/actions/workflows/dependencies.yml/badge.svg?branch=dev)](https://github.com/pmonks/spinner/actions?query=workflow%3Adependencies+branch%3Adev) |
-
-[![Latest Version](https://img.shields.io/clojars/v/com.github.pmonks/spinner)](https://clojars.org/com.github.pmonks/spinner/) [![Open Issues](https://img.shields.io/github/issues/pmonks/spinner.svg)](https://github.com/pmonks/spinner/issues) [![License](https://img.shields.io/github/license/pmonks/spinner.svg)](https://github.com/pmonks/spinner/blob/release/LICENSE)
-
 # spinner
+
+[![CI](https://github.com/pmonks/spinner/actions/workflows/ci.yml/badge.svg?branch=dev)](https://github.com/pmonks/spinner/actions?query=workflow%3ACI+branch%3Adev)
+[![Dependencies](https://github.com/pmonks/spinner/actions/workflows/dependencies.yml/badge.svg?branch=dev)](https://github.com/pmonks/spinner/actions?query=workflow%3Adependencies+branch%3Adev)
+<br/>
+[![Latest Version](https://img.shields.io/clojars/v/com.github.pmonks/spinner)](https://clojars.org/com.github.pmonks/spinner/)
+[![Open Issues](https://img.shields.io/github/issues/pmonks/spinner.svg)](https://github.com/pmonks/spinner/issues)
+[![License](https://img.shields.io/github/license/pmonks/spinner.svg)](https://github.com/pmonks/spinner/blob/release/LICENSE)
+![Maintained](https://badges.ws/badge/?label=maintained&value=yes,+at+author's+discretion)
 
 Progress indicators for command line Clojure apps, including support for indeterminate tasks (those where progress cannot be measured) and determinate tasks (those where progress can be measured).  The former are represented using "spinners", while the latter are represented using "progress bars".
 

--- a/deps.edn
+++ b/deps.edn
@@ -9,7 +9,7 @@
 ;
 
 {:deps
-   {jansi-clj/jansi-clj           {:mvn/version "1.0.3"}
+   {jansi-clj/jansi-clj           {:mvn/version "1.0.5"}
     com.github.pmonks/clj-wcwidth {:mvn/version "1.0.103"}
     com.github.pmonks/embroidery  {:mvn/version "1.0.44"}}
  :aliases

--- a/src/progress/ansi.clj
+++ b/src/progress/ansi.clj
@@ -30,15 +30,27 @@
   (print "\u001B8")          ; So we manually send a DEC code too
   (flush))
 
+(defn hide-cursor!
+  []
+  (print "\u001B[25l")
+  (flush))
+
+(defn show-cursor!
+  []
+  (print "\u001B[25h")
+  (flush))
+
 (defn print-at
   "Send text output to the specified screen locations (note: ANSI screen
   coordinates are 1-based). msgs may include jansi formatting."
   [x y & msgs]
   (save-cursor!)
+  (hide-cursor!)
   (jansi/cursor! x y)
   (jansi/erase-line!)
   (apply print msgs)
-  (restore-cursor!))
+  (restore-cursor!)
+  (show-cursor!))
 
 (defn debug-print-at
   "Send debug output to the specified screen location (note: ANSI screen

--- a/src/progress/determinate.clj
+++ b/src/progress/determinate.clj
@@ -60,7 +60,7 @@
 
 (defn- redraw-progress-indicator!
   "Redraws the progress indicator."
-  [style style-widths label line width counter? total units new-value]
+  [style style-widths label line width counter? total digits-in-total units new-value]
   ; Make sure this code is non re-entrant
   (locking lock
     (let [percent-complete (/ (double new-value) total)
@@ -75,7 +75,8 @@
           fill-cols        (clamp 0 body-cols (Math/ceil (* percent-complete body-cols)))
           fill-chars       (- (Math/ceil (/ fill-cols (:full style-widths))) tip-chars)
           empty-cols       (- body-cols (* fill-chars (:full style-widths)))  ; We do it this way due to rounding
-          empty-chars      (Math/floor (/ empty-cols (:empty style-widths)))]
+          empty-chars      (Math/floor (/ empty-cols (:empty style-widths)))
+          counter-pad      (- digits-in-total (count (str new-value)))]
       (when line
         (ansi/save-cursor!)
         (ansi/hide-cursor!)
@@ -123,7 +124,8 @@
                     (ansi/apply-colours-and-attrs (:counter-fg-colour style)
                                                   (:counter-bg-colour style)
                                                   (:counter-attrs     style)
-                                                  (str " " (int new-value) "/" (int total)
+                                                  (str (s/join (repeat (inc counter-pad) " "))  ; Left pad current counter value
+                                                       (int new-value) "/" (int total)
                                                        (when-not (s/blank? units)
                                                          (ansi/apply-colours-and-attrs (:units-fg-colour style)
                                                                                        (:units-bg-colour style)
@@ -210,7 +212,7 @@
                                     (when (:right style)       {:right (valid-width (:right style))})
                                     (when (:tip   style)       {:tip   (valid-width (:tip   style))})
                                     (when-not (s/blank? units) {:units (inc (valid-width units))}))  ; Include space delimiter
-            render-fn!       (partial redraw-progress-indicator! style style-widths label line width counter? total units)
+            render-fn!       (partial redraw-progress-indicator! style style-widths label line width counter? total (count (str total)) units)
             running-promise? (promise)
             poll-interval-ms (Math/round (double (/ 1000 redraw-rate)))
             fut              (e/future* (poll-atom a running-promise? poll-interval-ms render-fn!))]

--- a/src/progress/determinate.clj
+++ b/src/progress/determinate.clj
@@ -78,6 +78,7 @@
           empty-chars      (Math/floor (/ empty-cols (:empty style-widths)))]
       (when line
         (ansi/save-cursor!)
+        (ansi/hide-cursor!)
         (jansi/cursor! 1 line))
       (print (str ; Go to the start of the line
                   "\r"
@@ -130,6 +131,7 @@
                                                                                        (str " " units))))))))
       (jansi/erase-line!)
       (when line (ansi/restore-cursor!))
+      (ansi/show-cursor!)
       (flush))))
 
 (defn- poll-atom

--- a/src/progress/indeterminate.clj
+++ b/src/progress/indeterminate.clj
@@ -127,12 +127,14 @@
             attributes  [:default]}}]
     (let [delay-in-ms (long (Math/round (double delay-in-ms)))]  ; Coerce delay-in-ms to a long
       (ansi/save-cursor!)
+      (ansi/hide-cursor!)
       (loop [i 0]
         (clojure.core/print (str (ansi/apply-colours-and-attrs fg-colour bg-colour attributes (nth frames (mod i (count frames))))
                                  " "))
         (flush)
         (when (pos? delay-in-ms) (Thread/sleep delay-in-ms))  ; Thread/sleep throws on negative values, and sleeping for 0ms makes no sense
         (ansi/restore-cursor!)
+        (ansi/show-cursor!)
         (jansi/erase-line!)
         (print-pending-messages)
         (when (active?)


### PR DESCRIPTION
com.github.pmonks/spinner release 2.0.267. See commit log for details of what's included in this release.