### PR TITLE
Release 2.0.292

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java-version: [ 8, 11, 17, 21 ]
+        java-version: [ 8, 11, 17, 21, 25 ]
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-java@v5

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: 21
+          java-version: 25
       - uses: DeLaGuardo/setup-clojure@13.4
         with:
           cli: latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: 21
+          java-version: 25
       - uses: DeLaGuardo/setup-clojure@13.4
         with:
           cli: latest

--- a/README.md
+++ b/README.md
@@ -59,23 +59,23 @@ Doesn't work properly, for the same reason the `clj` command line doesn't work p
 ```clojure
 ;; Indeterminate Task (aka "spinner")
 
-(require '[progress.indeterminate :as pi])
+(require '[progress.indeterminate :as spinner])
 
 (print "Something uncountably slow is happening... ")
-(pi/animate! :opts {:frames (:clocks pi/styles)}
+(spinner/animate! :opts {:frames (:clocks spinner/styles)}
   (Thread/sleep 5000))
 (println)
 
 
 ;; Determinate Task (aka "progress bar")
 
-(require '[progress.determinate :as pd])
+(require '[progress.determinate :as progress-bar])
 
 (println "And now something countably slow is happening...")
 (let [a (atom 0)]
-  (pd/animate! a :opts {:total 1000000
-                        :redraw-rate 60  ; Use 60 fps for the demo
-                        :style (:coloured-ascii-boxes pd/styles)}  ; :emoji-boxes is also fun to try
+  (progress-bar/animate! a :opts {:total 1000000
+                                 :redraw-rate 60  ; Use 60 fps for the demo
+                                 :style (:coloured-ascii-boxes progress-bar/styles)}  ; :emoji-boxes is also fun to try
     (run! (fn [_] (Thread/sleep 0 10) (swap! a inc)) (range 1000000))))  ; Count up to a million, slowly
 (println)
 ```

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ Doesn't work properly, for the same reason the `clj` command line doesn't work p
 (println "And now something countably slow is happening...")
 (let [a (atom 0)]
   (progress-bar/animate! a :opts {:total 1000000
-                                 :redraw-rate 60  ; Use 60 fps for the demo
-                                 :style (:coloured-ascii-boxes progress-bar/styles)}  ; :emoji-boxes is also fun to try
+                                  :redraw-rate 60  ; Use 60 fps for the demo
+                                  :style (:coloured-ascii-boxes progress-bar/styles)}  ; :emoji-boxes is also fun to try
     (run! (fn [_] (Thread/sleep 0 10) (swap! a inc)) (range 1000000))))  ; Count up to a million, slowly
 (println)
 ```

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Here it is in action (from the [demo script](https://github.com/pmonks/spinner/b
   <img alt="Spinner example screenshot" src="https://raw.githubusercontent.com/pmonks/spinner/dev/spinner-demo.gif"/>
 </p>
 
-Note that using Unicode characters in progress indicators may be unreliable, depending on your OS, terminal, font, encoding, phase of the moon, etc.
+Note that using Unicode characters in progress indicators may be unreliable, depending on your OS, terminal, font, encoding, etc.
 
 ## Installation
 

--- a/demo.clj
+++ b/demo.clj
@@ -1,21 +1,21 @@
 ;; Indeterminate Task (aka "spinner")
 
-(require '[progress.indeterminate :as pi])
+(require '[progress.indeterminate :as spinner])
 
 (print "Something uncountably slow is happening... ")
-(pi/animate! :opts {:frames (:clocks pi/styles)}
+(spinner/animate! :opts {:frames (:clocks spinner/styles)}
   (Thread/sleep 5000))
 (println)
 
 
 ;; Determinate Task (aka "progress bar")
 
-(require '[progress.determinate :as pd])
+(require '[progress.determinate :as progress-bar])
 
 (println "And now something countably slow is happening...")
 (let [a (atom 0)]
-  (pd/animate! a :opts {:total 1000000
-                        :redraw-rate 60  ; Use 60 fps for the demo
-                        :style (:coloured-ascii-boxes pd/styles)}  ; :emoji-boxes is also fun to try
+  (progress-bar/animate! a :opts {:total 1000000
+                                 :redraw-rate 60  ; Use 60 fps for the demo
+                                 :style (:coloured-ascii-boxes progress-bar/styles)}  ; :emoji-boxes is also fun to try
     (run! (fn [_] (Thread/sleep 0 10) (swap! a inc)) (range 1000000))))  ; Count up to a million, slowly
 (println)

--- a/demo.clj
+++ b/demo.clj
@@ -15,7 +15,7 @@
 (println "And now something countably slow is happening...")
 (let [a (atom 0)]
   (progress-bar/animate! a :opts {:total 1000000
-                                 :redraw-rate 60  ; Use 60 fps for the demo
-                                 :style (:coloured-ascii-boxes progress-bar/styles)}  ; :emoji-boxes is also fun to try
+                                  :redraw-rate 60  ; Use 60 fps for the demo
+                                  :style (:coloured-ascii-boxes progress-bar/styles)}  ; :emoji-boxes is also fun to try
     (run! (fn [_] (Thread/sleep 0 10) (swap! a inc)) (range 1000000))))  ; Count up to a million, slowly
 (println)

--- a/deps.edn
+++ b/deps.edn
@@ -11,7 +11,10 @@
 {:deps
    {jansi-clj/jansi-clj           {:mvn/version "1.0.5"}
     com.github.pmonks/clj-wcwidth {:mvn/version "1.0.125"}
-    com.github.pmonks/embroidery  {:mvn/version "1.0.44"}}
+    com.github.pmonks/embroidery  {:mvn/version "1.0.44"}
+
+    ; Force the latest version of JANSI, since jansi-clj is out of date
+    org.fusesource.jansi/jansi    {:mvn/version "2.4.2"}}
  :aliases
    {:build {:deps       {com.github.pmonks/pbr {:mvn/version "RELEASE"}}
             :ns-default pbr.build}}}

--- a/src/progress/ansi.clj
+++ b/src/progress/ansi.clj
@@ -16,6 +16,13 @@
 
 (jansi/enable!)
 
+(def available?
+  "Are ANSI escape sequences available on this JVM's stdout?"
+  (case (.name (.getType (org.fusesource.jansi.AnsiConsole/out)))
+    "Unsupported" false
+    "Redirected"  false
+    true))
+
 (defn save-cursor!
   "Issues both SCO and DEC save-cursor ANSI codes, for maximum compatibility."
   []

--- a/src/progress/determinate.clj
+++ b/src/progress/determinate.clj
@@ -87,7 +87,7 @@
 
 (defn- redraw-progress-indicator!
   "Redraws the progress indicator."
-  [style unit-width-cols body-width-chars label line counter? total digits-in-total units new-value]
+  [style step-width-cols body-width-chars label line counter? total digits-in-total units new-value]
   ; Make sure this code is non re-entrant
   (locking lock
     (let [; How complete are we?
@@ -126,19 +126,19 @@
                     (ansi/apply-colours-and-attrs (:full-fg-colour style)
                                                   (:full-bg-colour style)
                                                   (:full-attrs     style)
-                                                  (s/join (repeat fill-chars (pad-to-width (:full style) unit-width-cols)))))
+                                                  (s/join (repeat fill-chars (pad-to-width (:full style) step-width-cols)))))
                   ; Tip (optional)
                   (when (and (:tip style) (pos? complete-chars))
                     (ansi/apply-colours-and-attrs (:tip-fg-colour style)
                                                   (:tip-bg-colour style)
                                                   (:tip-attrs     style)
-                                                  (pad-to-width (:tip style) unit-width-cols)))
+                                                  (pad-to-width (:tip style) step-width-cols)))
                   ; Empty
                   (when (pos? empty-chars)
                     (ansi/apply-colours-and-attrs (:empty-fg-colour style)
                                                   (:empty-bg-colour style)
                                                   (:empty-attrs     style)
-                                                  (s/join (repeat empty-chars (pad-to-width (:empty style) unit-width-cols)))))
+                                                  (s/join (repeat empty-chars (pad-to-width (:empty style) step-width-cols)))))
                   ; Right (optional)
                   (when (:right style)
                     (ansi/apply-colours-and-attrs (:right-fg-colour style)
@@ -205,7 +205,9 @@
   * `:width`     - the (approximate) desired width of the progress indicator,
                    including any labels and counters. This is approximate
                    because emoji-based styles may not take up an even fraction
-                   of the desired width. Optional, default: `72`
+                   of the desired width. Optional, default: attempts to
+                   determine current console width, or defaults to `72` if that
+                   cannot be determined.
   * `:total`     - the final number that the atom will reach. Optional, default:
                    `100` (i.e. the atom represents a %age)
   * `:units`     - a unit label (`String`) to display after the counter - this
@@ -218,58 +220,83 @@
                    `false` (erase it)
   * `:redraw-rate` - how many times per second `a` will be checked for changes,
                    and the progress indicator redrawn if the value of `a` has
-                   changed. Optional, default `10`"
+                   changed. Optional, default `10`
+
+  Notes:
+
+  * When the JVM's stdout stream doesn't support ANSI escape sequences (e.g.
+    when output is redirected to a file), `f` will be executed without any
+    animation occurring
+  * When the terminal the JVM is executing within is too small to display the
+    determinate progress indicator, `f` will be executed without any
+    animation occurring"
   ([a f] (animatef! a nil f))
   ([a
     {:keys [style label line width total units counter? preserve? redraw-rate]
        :or {style       (get styles default-style)
             total       100
-            width       72
+            width       (let [console-width (org.fusesource.jansi.AnsiConsole/getTerminalWidth)]
+                          (if (pos? console-width)
+                            (- console-width 2)  ; Allow space for the cursor
+                            72))
             counter?    true
             preserve?   false
             redraw-rate 10}}
     f]
     (when (and a f)
       (let [; We pre-compute a lot of stuff here, so that we're not doing it every pass through the rendering loop
-            label-width      (if-not (s/blank? label) (inc (valid-width label)) 0)  ; Include space delimiter
+
+            ; Label + space delimiter width
+            label-width      (if-not (s/blank? label) (inc (valid-width label)) 0)
+
+            ; Progress bar widths (all in columns)
             left-width       (if-not (s/blank? (:left style)) (valid-width (:left style)) 0)
             full-width       (valid-width (:full style))
             tip-width        (if-not (s/blank? (:tip style)) (valid-width (:tip style)) 0)
             empty-width      (valid-width (:empty style))
             right-width      (if-not (s/blank? (:right style)) (valid-width (:right style)) 0)
-            digits-in-total  (count (str total))
-            counter-width    (if counter? (+ 2 (* 2 digits-in-total))  0)  ; Include space delimiter, / delimiter, current value and total
-            units-width      (if (and counter? (not (s/blank? (:units style)))) (inc (valid-width (:units style))) 0)  ; Include space delimiter
-            body-width-cols  (- width label-width left-width right-width counter-width units-width)
-            unit-width-cols  (max empty-width full-width tip-width)
-            body-width-chars (round-down (/ body-width-cols unit-width-cols))
 
-            ; Now setup the rendering function with all that pre-computed stuff baked in, and fire it off in a future that polls the atom
-            render-fn!       (partial redraw-progress-indicator! style unit-width-cols body-width-chars label line counter? total digits-in-total units)
-            running-promise? (promise)
-            poll-interval-ms (round (/ 1000 redraw-rate))
-            fut              (e/future* (poll-atom a running-promise? poll-interval-ms render-fn!))]
-        (try
-          (f)
-          (finally
-            ; Teardown logic
-            (deliver running-promise? false)
-            @fut  ; Ensures any exceptions are rethrown
-            (locking lock  ; Make sure this isn't re-entrant with the future, since the TTY can only save a single cursor position at a time
-              (if preserve?
-                ; Make sure we draw the indicator with the final value of the atom
-                (do
-                  (render-fn! @a)
-                  (when-not line (println)))
-                ; Erase the line the indicator was on
-                (do
-                  (when line
-                    (ansi/save-cursor!)
-                    (jansi/cursor! 1 line))
-                  (print "\r")
-                  (jansi/erase-line!)
-                  (when line (ansi/restore-cursor!))))
-              (flush))))))))
+            ; Counter + units width (all in columns)
+            digits-in-total  (count (str total))
+            counter-width    (if counter? (+ 2 (* 2 digits-in-total)) 0)  ; Counter width: space delimiter, current value, "/" delimiter,  total
+            units-width      (if (and counter? (not (s/blank? units))) (inc (valid-width units)) 0)  ; Space delimiter + units width
+
+            ; Derived widths for the entire progress bar (mix of columns and chars)
+            body-width-cols  (- width label-width left-width right-width counter-width units-width)  ; Width of progress bar in cols
+            step-width-cols  (max empty-width full-width tip-width)  ; Width of a single "step" in the progress bar in cols (normally 1, but could be 2 if Unicode)
+            body-width-chars (round-down (/ body-width-cols step-width-cols))
+
+            ; Full width of entire animation
+            animation-width  (+ label-width body-width-cols counter-width units-width)]
+          ; Only animate if stdout attached to the running JVM supports ANSI and the terminal width is large enough
+          (if-not (and ansi/available? (>= width animation-width))
+            (f)
+            (let [; Setup the rendering function with all that pre-computed stuff baked in, and fire it off in a future that polls the atom
+                  render-fn!       (partial redraw-progress-indicator! style step-width-cols body-width-chars label line counter? total digits-in-total units)
+                  running-promise? (promise)
+                  poll-interval-ms (round (/ 1000 redraw-rate))
+                  fut              (e/future* (poll-atom a running-promise? poll-interval-ms render-fn!))]
+              (try
+                (f)
+                (finally
+                  ; Teardown logic
+                  (deliver running-promise? false)
+                  @fut  ; Ensures any exceptions are rethrown
+                  (locking lock  ; Make sure this isn't re-entrant with the future, since the TTY can only save a single cursor position at a time
+                    (if preserve?
+                      ; Make sure we draw the indicator with the final value of the atom
+                      (do
+                        (render-fn! @a)
+                        (when-not line (println)))
+                      ; Erase the line the indicator was on
+                      (do
+                        (when line
+                          (ansi/save-cursor!)
+                          (jansi/cursor! 1 line))
+                        (print "\r")
+                        (jansi/erase-line!)
+                        (when line (ansi/restore-cursor!))))
+                    (flush))))))))))
 
 (defmacro animate!
   "Equivalent to `clojure.core/do`, but displays a determinate progress
@@ -290,7 +317,9 @@
   * `:width`     - the (approximate) desired width of the progress indicator,
                    including any labels and counters. This is approximate
                    because emoji-based styles may not take up an even fraction
-                   of the desired width. Optional, default: `72`
+                   of the desired width. Optional, default: attempts to
+                   determine current console width, or defaults to `72` if that
+                   cannot be determined.
   * `:total`     - the final number that the atom will reach. Optional, default:
                    `100` (i.e. the atom represents a %age)
   * `:units`     - a unit label (`String`) to display after the counter - this
@@ -303,7 +332,16 @@
                    indicator. Optional, default: `true` (display a counter)
   * `:redraw-rate` - how many times per second `a` will be checked for changes,
                    and the progress indicator redrawn if the value of `a` has
-                   changed. Optional, default `10`"
+                   changed. Optional, default `10`
+
+  Notes:
+
+  * When the JVM's stdout stream doesn't support ANSI escape sequences (e.g.
+    when output is redirected to a file), the forms will be executed without any
+    animation occurring
+  * When the terminal the JVM is executing within is too small to display the
+    determinate progress indicator, the forms will be executed without any
+    animation occurring"
   [a & body]
   (if (= :opts (first body))
     `(animatef! ~a ~(second body) (fn [] ~@(rest (rest body))))

--- a/src/progress/determinate.clj
+++ b/src/progress/determinate.clj
@@ -272,10 +272,11 @@
               (flush))))))))
 
 (defmacro animate!
-  "Wraps execution of the given forms in a determinate progress indicator,
-  monitoring atom `a` (a number between `0` and `(:total opts)`, representing
-  progress). If the first form is the keyword `:opts`, the second form _must_ be
-  a map, containing any/all of these keys:
+  "Equivalent to `clojure.core/do`, but displays a determinate progress
+  indicator (aka 'progress bar') while the forms are executing. Monitors atom
+  `a` (a number between `0` and `(:total opts)`), representing progress by those
+  forms. If the first form is the keyword `:opts`, the second form _must_ be a
+  map, containing any/all of these keys:
 
   * `:style`     - a map defining the style (characters, colours, and
                    attributes) to use when printing the progress indicator.

--- a/src/progress/indeterminate.clj
+++ b/src/progress/indeterminate.clj
@@ -213,9 +213,10 @@
          (stop!))))))
 
 (defmacro animate!
-  "Wraps the given forms in an indeterminate progress indicator. If the first
-  form is the keyword `:opts`, the second form _must_ be a map, containing
-  any/all of these keys:
+  "Equivalent to `clojure.core/do`, but displays an indeterminate progress
+  indicator (aka 'spinner') while the forms are executing. If the first form is
+  the keyword `:opts`, the second form _must_ be a map, containing any/all of
+  these keys:
 
   * `:frames`      - the frames (a sequence of `String`s) to use for the
                      indeterminate progress indicator (default is

--- a/src/progress/indeterminate.clj
+++ b/src/progress/indeterminate.clj
@@ -54,9 +54,10 @@
   [& more]
   (when (seq more)
     (let [msg (s/join " " more)]
-      (if (= @s :active)
+      ; If ANSI escape sequences aren't available or a progress indicator isn't active, print immediately
+      (if (and ansi/available? (= @s :active))
         (swap! msgs str msg)
-        (clojure.core/print msg))))   ; If a progress indicator isn't active, just print immediately
+        (clojure.core/print msg))))
   nil)
 
 (defn- print-pending-messages
@@ -202,15 +203,25 @@
                      printed after the indeterminate progress indicator. This
                      can be more visually appealing when using Unicode frames as
                      it creates some separation with the cursor.
-                     (default is `true`)"
+                     (default is `true`)
+
+  Notes:
+
+  * When the JVM's stdout stream doesn't support ANSI escape sequences (e.g.
+    when output is redirected to a file), `f` will be executed without any
+    animation occurring"
   ([f] (animatef! nil f))
   ([opts f]
     (when f
-      (start! opts)
-      (try
-       (f)
-       (finally
-         (stop!))))))
+      ; Only animate if stdout attached to the running JVM supports ANSI
+      (if-not ansi/available?
+        (f)
+        (do
+          (start! opts)
+          (try
+           (f)
+           (finally
+             (stop!))))))))
 
 (defmacro animate!
   "Equivalent to `clojure.core/do`, but displays an indeterminate progress
@@ -240,7 +251,13 @@
                      printed after the indeterminate progress indicator. This
                      can be more visually appealing when using Unicode frames as
                      it creates some separation with the cursor.
-                     (default is `true`)"
+                     (default is `true`)
+
+  Notes:
+
+  * When the JVM's stdout stream doesn't support ANSI escape sequences (e.g.
+    when output is redirected to a file), the forms will be executed without any
+    animation occurring"
   [& body]
   (if (= :opts (first body))
     `(animatef! ~(second body) (fn [] ~@(rest (rest body))))

--- a/test/progress/indeterminate_test.clj
+++ b/test/progress/indeterminate_test.clj
@@ -11,6 +11,7 @@
 (ns progress.indeterminate-test
   (:require [clojure.test           :refer [deftest testing is]]
             [jansi-clj.core         :as jansi]
+            [progress.ansi          :as ansi]
             [progress.test-utils    :refer [skip-slow-tests?]]
             [progress.indeterminate :as pi]))
 
@@ -26,8 +27,10 @@
   (testing "Not active when not running"
     (is (false? (pi/active?))))
 
-  (testing "Active when running"
-    (is (true? (pi/animatef! (fn [] (pi/active?)))))))
+  (testing "Active when running on ANSI-enabled terminal"
+    (if ansi/available?
+      (is (true?  (pi/animatef! (fn [] (pi/active?)))))
+      (is (false? (pi/animatef! (fn [] (pi/active?))))))))
 
 (deftest test-function-vs-macro
   (testing "No code provided - animatef! fn"


### PR DESCRIPTION
com.github.pmonks/spinner release 2.0.292. See commit log for details of what's included in this release.